### PR TITLE
update SetAsset

### DIFF
--- a/src/components/setting/SetAsset.vue
+++ b/src/components/setting/SetAsset.vue
@@ -130,7 +130,7 @@ export default {
     // cookie에 저장 된 은행 별 자산 불러옴.
     for (let i = 0; i < this.$store.state.bankAsset.bank.length; i++) {
       // 1) cookie에 저장된 은행 수만큼 화면에 상자 생기게 해줌.
-      this.saveAsset.banks.push({ bank: '', asset: 0, id: makeID('bank') });
+      this.saveAsset.banks.push({ bank: '', asset: 0, id: '' });
       // 2) 은행명, 은행별 자산, 은행별 아이디 각각 넣어줌.
       this.saveAsset.banks[i].bank = this.$store.state.bankAsset.bank[i];
       this.saveAsset.banks[i].asset = this.$store.state.bankAsset.asset[i];

--- a/src/utils/cookies.js
+++ b/src/utils/cookies.js
@@ -139,24 +139,6 @@ function getCategoryCookie() {
   categoryArr.splice('', 1);
 
   return categoryArr;
-
-  // // *** 3. 카테고리명과 아이콘주소를 모은 각각의 배열 생성 ***
-  // for (let i = 0; i < categoryArr.length; i++) {
-  //   let iconId = categoryArr[i].slice(
-  //     categoryArr[i].indexOf('|') + 1,
-  //     categoryArr[i].legnth,
-  //   );
-
-  //   store.state.categorys.name.push(
-  //     categoryArr[i].slice(0, categoryArr[i].indexOf('|')),
-  //   );
-  //   store.state.categorys.icon.push(
-  //     iconId.replace(iconId.substr(iconId.indexOf('|'), iconId.length), ''),
-  //   );
-  //   store.state.categorys.id.push(
-  //     iconId.slice(iconId.indexOf('|') + 1, iconId.length),
-  //   );
-  // }
 }
 function getCategoryCookieName() {
   let categoryArr = getCategoryCookie();


### PR DESCRIPTION
cookie에 저장된 은행 별 자산 데이터 불러올 때, 저장 된 목록 개수만큼 화면에 for문으로 돌리는 부분의 id부분 수정.
(기존에는 새로운 id가 생기도록 되어있었음. 수정 후 ''으로 체인지. - cookie에 저장 된 id가 들어가도록.)